### PR TITLE
[Design/Feat] 산책 지원 - 전달 메세지 UI 구현

### DIFF
--- a/walkmong/walkmong.xcodeproj/project.pbxproj
+++ b/walkmong/walkmong.xcodeproj/project.pbxproj
@@ -251,7 +251,6 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QC8QR8UH59;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = walkmong/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "워크멍";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -290,7 +289,6 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QC8QR8UH59;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = walkmong/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "워크멍";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/walkmong/walkmong/Extension/NavigationBar.swift
+++ b/walkmong/walkmong/Extension/NavigationBar.swift
@@ -13,6 +13,7 @@ extension UIViewController {
         
         let navigationBarView = UIView()
         navigationBarView.backgroundColor = .white
+        self.navigationController?.setNavigationBarHidden(true, animated: true)
         self.view.addSubview(navigationBarView)
         
         navigationBarView.snp.makeConstraints { make in

--- a/walkmong/walkmong/MatchingApplyProcedure/Controllers/MatchingApplyMessageViewController.swift
+++ b/walkmong/walkmong/MatchingApplyProcedure/Controllers/MatchingApplyMessageViewController.swift
@@ -8,22 +8,38 @@
 import UIKit
 
 class MatchingApplyMessageViewController: UIViewController {
+    
+    let messageView = MatchingApplyMessageView()
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        self.view.backgroundColor = .white
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.didTapTextView(_:)))
+        view.addGestureRecognizer(tapGesture)
+        addCustomNavigationBar(titleText: "산책 지원하기", showLeftBackButton: true, showLeftCloseButton: false, showRightCloseButton: false, showRightRefreshButton: false)
+        addProgressBar(currentStep: 2, totalSteps: 3)
+        addSubviews()
+        setConstraints()
+        messageView.delegate = self
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    private func addSubviews(){
+        self.view.addSubview(messageView)
     }
-    */
-
+    
+    private func setConstraints(){
+        messageView.snp.makeConstraints{ make in
+            make.top.equalToSuperview().offset(152)
+            make.bottom.horizontalEdges.equalToSuperview()
+        }
+    }
+    @objc private func didTapTextView(_ sender: Any) {
+        view.endEditing(true)
+    }
+}
+extension MatchingApplyMessageViewController: MatchingApplyMessageViewDelegate {
+    func didTapNextButton() {
+        let nextVC = MatchingApplyFinalViewController()
+        self.navigationController?.pushViewController(nextVC, animated: true)
+    }
 }

--- a/walkmong/walkmong/MatchingApplyProcedure/Views/MatchingApplyMessageView.swift
+++ b/walkmong/walkmong/MatchingApplyProcedure/Views/MatchingApplyMessageView.swift
@@ -1,0 +1,144 @@
+//
+//  MatchingApplyMessageView.swift
+//  walkmong
+//
+//  Created by 황채웅 on 11/14/24.
+//
+
+import UIKit
+
+protocol MatchingApplyMessageViewDelegate: AnyObject {
+    func didTapNextButton()
+}
+
+class MatchingApplyMessageView: UIView {
+    
+    weak var delegate: MatchingApplyMessageViewDelegate?
+    private var characterCount = 0
+        
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "반려인에게 전달할 메세지"
+        label.textColor = .mainBlack
+        label.font = UIFont(name: "Pretendard-Bold", size: 24)
+        return label
+    }()
+    
+    private let textViewPlaceHolder = "반려견의 보호자에게 전할 말이 있다면 작성해주세요."
+    
+    private lazy var messageTextView: UITextView = {
+        let textView = UITextView()
+        textView.textContainerInset = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
+        textView.textColor = .gray500
+        textView.backgroundColor = .gray100
+        textView.layer.cornerRadius = 5
+        textView.text = textViewPlaceHolder
+        textView.textAlignment = .left
+        textView.font = UIFont(name: "Pretendard-Regular", size: 16)
+        textView.showsVerticalScrollIndicator = false
+        return textView
+    }()
+    
+    private lazy var remainCountLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont(name: "Pretendard-Medium", size: 16)
+        label.textAlignment = .center
+        label.textColor = .gray400
+        let fullText = "(0/250)"
+        let attributedString = NSMutableAttributedString(string: fullText)
+        let countRange = (fullText as NSString).range(of: "0")
+        attributedString.addAttribute(.foregroundColor, value: UIColor.mainBlue, range: countRange)
+        label.attributedText = attributedString
+        return label
+    }()
+    
+    private let nextButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("다음으로", for: .normal)
+        button.titleLabel?.font = UIFont(name: "Pretendard-SemiBold", size: 16)
+        button.titleLabel?.textColor = .white
+        button.backgroundColor = .gray300
+        button.layer.cornerRadius = 15
+        button.addTarget(MatchingApplyMessageView.self, action: #selector(nextButtonTapped), for: .touchUpInside)
+        return button
+    }()
+
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        addSubviews()
+        setConstraints()
+        messageTextView.delegate = self
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func addSubviews(){
+        addSubviews(titleLabel, messageTextView, remainCountLabel, nextButton)
+    }
+    
+    private func setConstraints(){
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(26)
+            make.horizontalEdges.equalToSuperview().inset(20)
+        }
+        messageTextView.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(20)
+            make.horizontalEdges.equalToSuperview().inset(20)
+            make.height.equalTo(169)
+        }
+        remainCountLabel.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(155)
+            make.trailing.equalToSuperview().inset(32)
+        }
+        nextButton.snp.makeConstraints { make in
+            make.height.equalTo(54)
+            make.horizontalEdges.equalToSuperview().inset(20)
+            make.bottom.equalToSuperview().inset(58)
+        }
+    }
+    
+    @objc private func nextButtonTapped(){
+        if characterCount > 0 {
+            delegate?.didTapNextButton()
+        }
+    }
+}
+
+extension MatchingApplyMessageView: UITextViewDelegate {
+    
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.text == textViewPlaceHolder {
+            textView.text = nil
+        }
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            textView.text = textViewPlaceHolder
+        }
+    }
+    
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        let inputString = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let oldString = textView.text, let newRange = Range(range, in: oldString) else { return true }
+        let newString = oldString.replacingCharacters(in: newRange, with: inputString).trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        characterCount = newString.count
+        guard characterCount <= 250 else { return false }
+        updateCount(characterCount: characterCount)
+        return true
+    }
+    private func updateCount(characterCount: Int) {
+        nextButton.backgroundColor = characterCount > 0 ? .gray600 : .gray300
+        let fullText = "(\(characterCount)/250)"
+        let attributedString = NSMutableAttributedString(string: fullText)
+        let remainingRange = NSRange(location: 0, length: fullText.count)
+        attributedString.addAttribute(.foregroundColor, value: UIColor.gray400, range: remainingRange)
+        let countRange = (fullText as NSString).range(of: "\(characterCount)")
+        attributedString.addAttribute(.foregroundColor, value: UIColor.mainBlue, range: countRange)
+        remainCountLabel.attributedText = attributedString
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!--ex) #이슈번호, #이슈번호-->
#46 

### #️⃣ 이슈 닫기
<!--'close #이슈번호' 입력하면 됩니다!-->
close #46 

## 📝 작업 내용
<!--이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)-->
- [x] TextView 사용
- [x] 글자 수 세기 구현
- [x] 글자 수 제한 구현

### 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
<!--작업 중 궁금한 내용이나 논의할 사항을 적어주세요!-->
`NSMutableAttributedString`에서만 자간, 행간을 조정할 수 있는데,
이게 `UITextView`의 딜리게이트 메소드 내부의 글자 수를 세는 로직과 맞지 않아서 자모음이 분리되네요.. 
나중에 방법을 찾아서 적용해야겠습니다! 현재는 `UITextView.text`를 사용해서 자간, 행간은 적용되지 않았습니다
