### PR TITLE
[Refactor] KeyboardEventManager 구현

### DIFF
--- a/walkmong/walkmong/Application/AppDelegate.swift
+++ b/walkmong/walkmong/Application/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
-        NMFAuthManager.shared().clientId = SecretManager.shared.NAVER_CLIENT_ID
+        NMFAuthManager.shared().clientId = SecretManager.shared.NAVER_CLI_ID
         return true
     }
 

--- a/walkmong/walkmong/Global/Components/KeyboardEventManager.swift
+++ b/walkmong/walkmong/Global/Components/KeyboardEventManager.swift
@@ -1,0 +1,57 @@
+//
+//  KeyboardEventManager.swift
+//  walkmong
+//
+//  Created by 황채웅 on 12/30/24.
+//
+
+import Foundation
+import UIKit
+
+protocol KeyboardObserverDelegate: AnyObject {
+    func keyboardWillShow(keyboardHeight: CGFloat)
+    func keyboardWillHide()
+}
+
+class KeyboardEventManager {
+    weak var delegate: KeyboardObserverDelegate?
+
+    init(delegate: KeyboardObserverDelegate) {
+        self.delegate = delegate
+        setUpKeyboardNotifications()
+    }
+
+    deinit {
+        removeKeyboardNotifications()
+    }
+
+    private func setUpKeyboardNotifications() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(keyboardWillShow(_:)),
+                                               name: UIResponder.keyboardWillShowNotification,
+                                               object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(keyboardWillHide(_:)),
+                                               name: UIResponder.keyboardWillHideNotification,
+                                               object: nil)
+    }
+
+    private func removeKeyboardNotifications() {
+        NotificationCenter.default.removeObserver(self,
+                                                  name: UIResponder.keyboardWillShowNotification,
+                                                  object: nil)
+        NotificationCenter.default.removeObserver(self,
+                                                  name: UIResponder.keyboardWillHideNotification,
+                                                  object: nil)
+    }
+
+    @objc private func keyboardWillShow(_ notification: Notification) {
+        guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
+        let keyboardHeight = keyboardFrame.cgRectValue.height
+        delegate?.keyboardWillShow(keyboardHeight: keyboardHeight)
+    }
+
+    @objc private func keyboardWillHide(_ notification: Notification) {
+        delegate?.keyboardWillHide()
+    }
+}

--- a/walkmong/walkmong/Global/Extension/UIViewController+.swift
+++ b/walkmong/walkmong/Global/Extension/UIViewController+.swift
@@ -9,7 +9,7 @@ import UIKit
 
 extension UIViewController {
     
-    func dismissKeyboardOnTap(for view: UIView) {
+    func dismissKeyboardOnTap() {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         tapGesture.cancelsTouchesInView = false
         view.addGestureRecognizer(tapGesture)
@@ -17,34 +17,6 @@ extension UIViewController {
     
     @objc private func dismissKeyboard() {
         view.endEditing(true)
-    }
-    
-    func setupKeyboardEvent(for targetView: UIView) {
-        dismissKeyboardOnTap(for: targetView)
-        
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(keyboardWillShow),
-                                               name: UIResponder.keyboardWillShowNotification,
-                                               object: targetView)
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(keyboardWillHide),
-                                               name: UIResponder.keyboardWillHideNotification,
-                                               object: targetView)
-    }
-    
-    
-    @objc private func keyboardWillShow(_ sender: Notification, for targetView: UIView) {
-        guard let keyboardFrame = sender.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
-        let keyboardHeight = keyboardFrame.cgRectValue.height
-        if targetView.frame.origin.y == 0 {
-            targetView.frame.origin.y -= keyboardHeight
-        }
-    }
-    
-    @objc private func keyboardWillHide(_ sender: Notification, for targetView: UIView) {
-        if targetView.frame.origin.y != 0 {
-            targetView.frame.origin.y = 0
-        }
     }
     
 }

--- a/walkmong/walkmong/Global/Extension/UIViewController+.swift
+++ b/walkmong/walkmong/Global/Extension/UIViewController+.swift
@@ -18,5 +18,4 @@ extension UIViewController {
     @objc private func dismissKeyboard() {
         view.endEditing(true)
     }
-    
 }

--- a/walkmong/walkmong/Global/Extension/UIViewController+.swift
+++ b/walkmong/walkmong/Global/Extension/UIViewController+.swift
@@ -7,43 +7,44 @@
 
 import UIKit
 
-// Extend UIViewController to dismiss keyboard when tapping outside the UITextField
 extension UIViewController {
     
-    // Dismiss the keyboard when tapping anywhere on the view
-    func dismissKeyboardOnTap() {
+    func dismissKeyboardOnTap(for view: UIView) {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         tapGesture.cancelsTouchesInView = false
         view.addGestureRecognizer(tapGesture)
     }
     
-    func setupKeyboardEvent() {
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(keyboardWillShow),
-                                               name: UIResponder.keyboardWillShowNotification,
-                                               object: nil)
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(keyboardWillHide),
-                                               name: UIResponder.keyboardWillHideNotification,
-                                               object: nil)
-    }
-    
-    @objc func keyboardWillShow(_ sender: Notification) {
-        guard let keyboardFrame = sender.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
-        let keyboardHeight = keyboardFrame.cgRectValue.height
-        if view.frame.origin.y == 0 {
-            view.frame.origin.y -= keyboardHeight
-        }
-    }
-
-    @objc func keyboardWillHide(_ sender: Notification) {
-        if view.frame.origin.y != 0 {
-            view.frame.origin.y = 0
-        }
-    }
-    
-    // Dismiss keyboard method
     @objc private func dismissKeyboard() {
         view.endEditing(true)
     }
+    
+    func setupKeyboardEvent(for targetView: UIView) {
+        dismissKeyboardOnTap(for: targetView)
+        
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(keyboardWillShow),
+                                               name: UIResponder.keyboardWillShowNotification,
+                                               object: targetView)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(keyboardWillHide),
+                                               name: UIResponder.keyboardWillHideNotification,
+                                               object: targetView)
+    }
+    
+    
+    @objc private func keyboardWillShow(_ sender: Notification, for targetView: UIView) {
+        guard let keyboardFrame = sender.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
+        let keyboardHeight = keyboardFrame.cgRectValue.height
+        if targetView.frame.origin.y == 0 {
+            targetView.frame.origin.y -= keyboardHeight
+        }
+    }
+    
+    @objc private func keyboardWillHide(_ sender: Notification, for targetView: UIView) {
+        if targetView.frame.origin.y != 0 {
+            targetView.frame.origin.y = 0
+        }
+    }
+    
 }

--- a/walkmong/walkmong/Network/Foundation/APIEndpoint.swift
+++ b/walkmong/walkmong/Network/Foundation/APIEndpoint.swift
@@ -40,7 +40,7 @@ extension APIEndpoint {
             // TODO: 로그인 화면 이동
             return
         }
-        // TODO: Refresh Token 발급 API 호출
+        // TODO: Access Token 재발급 API 호출
     }
 
 }

--- a/walkmong/walkmong/Network/Service/DogService.swift
+++ b/walkmong/walkmong/Network/Service/DogService.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct UserService {
+struct DogService {
     private let provider = NetworkProvider<DogAPI>()
     
     func getDogList() async throws -> DogListResponse {

--- a/walkmong/walkmong/Presentation/MatchingApply/Map/ViewController/MatchingApplyMapViewController.swift
+++ b/walkmong/walkmong/Presentation/MatchingApply/Map/ViewController/MatchingApplyMapViewController.swift
@@ -7,15 +7,18 @@
 
 import UIKit
 import NMapsMap
-import Alamofire
-
+import SnapKit
 
 class MatchingApplyMapViewController: UIViewController {
-        
+    
     let matchingApplyMapView = MatchingApplyMapView()
     let modalView = MatchingApplyMapNotifyModalView()
     let addressModalView = MatchingApplyMapAddressModalView()
     var model = MatchingApplyMapModel(didSelectLocation: false)
+    private var keyboardEventManager: KeyboardEventManager?
+    
+    private var matchingApplyMapViewBottomConstraint: Constraint?
+    private var addressModalTopConstraint: Constraint?
 
     override func viewWillAppear(_ animated: Bool) {
         navigationController?.setNavigationBarHidden(true, animated: animated)
@@ -27,6 +30,8 @@ class MatchingApplyMapViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setConfigure()
+        dismissKeyboardOnTap()
+        keyboardEventManager = KeyboardEventManager(delegate: self)
     }
     
     private func setConfigure(){
@@ -49,7 +54,7 @@ class MatchingApplyMapViewController: UIViewController {
     private func setConstraints(){
         matchingApplyMapView.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(52)
-            make.bottom.equalToSuperview()
+            matchingApplyMapViewBottomConstraint = make.bottom.equalToSuperview().constraint
             make.horizontalEdges.equalToSuperview()
         }
         modalView.snp.makeConstraints { make in
@@ -59,7 +64,7 @@ class MatchingApplyMapViewController: UIViewController {
         addressModalView.snp.makeConstraints { make in
             make.height.equalTo(341)
             make.horizontalEdges.equalToSuperview()
-            make.top.equalTo(view.snp.bottom)
+            addressModalTopConstraint = make.top.equalTo(view.snp.bottom).constraint
         }
     }
     
@@ -68,7 +73,25 @@ class MatchingApplyMapViewController: UIViewController {
     }
 }
 
-extension MatchingApplyMapViewController: MatchingApplyMapViewDelegate{
+extension MatchingApplyMapViewController: KeyboardObserverDelegate {
+    func keyboardWillShow(keyboardHeight: CGFloat) {
+        matchingApplyMapViewBottomConstraint?.update(offset: -keyboardHeight)
+        addressModalTopConstraint?.update(offset: -keyboardHeight)
+        UIView.animate(withDuration: 0.3) {
+            self.view.layoutIfNeeded()
+        }
+    }
+
+    func keyboardWillHide() {
+        matchingApplyMapViewBottomConstraint?.update(offset: 0)
+        addressModalTopConstraint?.update(offset: 0)
+        UIView.animate(withDuration: 0.3) {
+            self.view.layoutIfNeeded()
+        }
+    }
+}
+
+extension MatchingApplyMapViewController: MatchingApplyMapViewDelegate {
     func willSelectLocation() {
         self.model.didSelectLocation = false
     }

--- a/walkmong/walkmong/Presentation/MatchingApply/Map/ViewController/MatchingApplyMapViewController.swift
+++ b/walkmong/walkmong/Presentation/MatchingApply/Map/ViewController/MatchingApplyMapViewController.swift
@@ -33,8 +33,7 @@ class MatchingApplyMapViewController: UIViewController {
         self.view.backgroundColor = .white
         modalView.delegate = self
         addressModalView.delegate = self
-        dismissKeyboardOnTap()
-        setupKeyboardEvent()
+        setupKeyboardEvent(for: matchingApplyMapView)
         setMapView()
     }
     private func setUI(){

--- a/walkmong/walkmong/Presentation/MatchingApply/Map/ViewController/MatchingApplyMapViewController.swift
+++ b/walkmong/walkmong/Presentation/MatchingApply/Map/ViewController/MatchingApplyMapViewController.swift
@@ -33,7 +33,6 @@ class MatchingApplyMapViewController: UIViewController {
         self.view.backgroundColor = .white
         modalView.delegate = self
         addressModalView.delegate = self
-        setupKeyboardEvent(for: matchingApplyMapView)
         setMapView()
     }
     private func setUI(){

--- a/walkmong/walkmong/Presentation/MatchingApply/PlaceSearch/ViewController/MatchingApplyPlaceSearchViewController.swift
+++ b/walkmong/walkmong/Presentation/MatchingApply/PlaceSearch/ViewController/MatchingApplyPlaceSearchViewController.swift
@@ -20,7 +20,7 @@ final class MatchingApplyPlaceSearchViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupKeyboardEvent(for: placeSearchView)
+        dismissKeyboardOnTap()
         addCustomNavigationBar(titleText: "만남장소", showLeftBackButton: true, showLeftCloseButton: false, showRightCloseButton: false, showRightRefreshButton: false)
         setUpViews()
         setConstraints()

--- a/walkmong/walkmong/Presentation/MatchingApply/PlaceSearch/ViewController/MatchingApplyPlaceSearchViewController.swift
+++ b/walkmong/walkmong/Presentation/MatchingApply/PlaceSearch/ViewController/MatchingApplyPlaceSearchViewController.swift
@@ -20,7 +20,7 @@ final class MatchingApplyPlaceSearchViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        dismissKeyboardOnTap()
+        setupKeyboardEvent(for: placeSearchView)
         addCustomNavigationBar(titleText: "만남장소", showLeftBackButton: true, showLeftCloseButton: false, showRightCloseButton: false, showRightRefreshButton: false)
         setUpViews()
         setConstraints()

--- a/walkmong/walkmong/Presentation/Walktalk/Chat/ViewController/WalktalkChatViewController.swift
+++ b/walkmong/walkmong/Presentation/Walktalk/Chat/ViewController/WalktalkChatViewController.swift
@@ -21,6 +21,7 @@ class WalktalkChatViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .white
         setUI()
+        setUpKeyboardEvent()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -49,22 +50,21 @@ class WalktalkChatViewController: UIViewController {
 
         walktalkChatView.setupTextViewDelegate(delegate: self)
         addCustomNavigationBar(titleText: "유저 이름", showLeftBackButton: true, showLeftCloseButton: false, showRightCloseButton: false, showRightRefreshButton: false)
-        dismissKeyboardOnTap()
-        setUpKeyboardEvent()
     }
     
     private func setUpKeyboardEvent() {
+        dismissKeyboardOnTap(for: view)
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(keyboardWillShow),
+                                               selector: #selector(chatKeyboardWillShow),
                                                name: UIResponder.keyboardWillShowNotification,
                                                object: nil)
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(keyboardWillHide),
+                                               selector: #selector(chatKeyboardWillHide),
                                                name: UIResponder.keyboardWillHideNotification,
                                                object: nil)
     }
 
-    @objc override func keyboardWillShow(_ sender: Notification) {
+    @objc private func chatKeyboardWillShow(_ sender: Notification) {
         guard let keyboardFrame = sender.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
         let keyboardHeight = keyboardFrame.cgRectValue.height
 
@@ -78,8 +78,8 @@ class WalktalkChatViewController: UIViewController {
     }
 
 
-    @objc override func keyboardWillHide(_ sender: Notification) {
-        // 컨테이너 뷰의 bottom 제약 조건 복원
+    @objc private func chatKeyboardWillHide(_ sender: Notification) {
+        
         containerBottomConstraint?.update(offset: -38)
 
         UIView.animate(withDuration: 0.3) {

--- a/walkmong/walkmong/Presentation/Walktalk/Chat/ViewController/WalktalkChatViewController.swift
+++ b/walkmong/walkmong/Presentation/Walktalk/Chat/ViewController/WalktalkChatViewController.swift
@@ -53,7 +53,7 @@ class WalktalkChatViewController: UIViewController {
     }
     
     private func setUpKeyboardEvent() {
-        dismissKeyboardOnTap(for: view)
+        dismissKeyboardOnTap()
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(chatKeyboardWillShow),
                                                name: UIResponder.keyboardWillShowNotification,
@@ -72,7 +72,6 @@ class WalktalkChatViewController: UIViewController {
 
         UIView.animate(withDuration: 0.3) {
             self.view.layoutIfNeeded()
-        } completion: { _ in
             self.walktalkChatView.scrollToBottom()
         }
     }

--- a/walkmong/walkmong/Presentation/Walktalk/Chat/ViewController/WalktalkChatViewController.swift
+++ b/walkmong/walkmong/Presentation/Walktalk/Chat/ViewController/WalktalkChatViewController.swift
@@ -16,6 +16,8 @@ class WalktalkChatViewController: UIViewController {
     private let currentMatchingState: MatchingState = .matching
 
     private var containerBottomConstraint: Constraint?
+    private var keyboardEventManager: KeyboardEventManager?
+
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -53,38 +55,11 @@ class WalktalkChatViewController: UIViewController {
     }
     
     private func setUpKeyboardEvent() {
+        walktalkChatView.setupTextViewDelegate(delegate: self)
+        keyboardEventManager = KeyboardEventManager(delegate: self)
         dismissKeyboardOnTap()
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(chatKeyboardWillShow),
-                                               name: UIResponder.keyboardWillShowNotification,
-                                               object: nil)
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(chatKeyboardWillHide),
-                                               name: UIResponder.keyboardWillHideNotification,
-                                               object: nil)
     }
 
-    @objc private func chatKeyboardWillShow(_ sender: Notification) {
-        guard let keyboardFrame = sender.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
-        let keyboardHeight = keyboardFrame.cgRectValue.height
-
-        containerBottomConstraint?.update(offset: -keyboardHeight)
-
-        UIView.animate(withDuration: 0.3) {
-            self.view.layoutIfNeeded()
-            self.walktalkChatView.scrollToBottom()
-        }
-    }
-
-
-    @objc private func chatKeyboardWillHide(_ sender: Notification) {
-        
-        containerBottomConstraint?.update(offset: -38)
-
-        UIView.animate(withDuration: 0.3) {
-            self.view.layoutIfNeeded()
-        }
-    }
 }
 
 extension WalktalkChatViewController: UITextViewDelegate {
@@ -103,7 +78,24 @@ extension WalktalkChatViewController: UITextViewDelegate {
     }
     
     func textViewDidChange(_ textView: UITextView) {
-        // 텍스트뷰가 변경될 때 View에 알림
         walktalkChatView.updateTextViewHeight()
+    }
+}
+
+
+extension WalktalkChatViewController: KeyboardObserverDelegate {
+    func keyboardWillShow(keyboardHeight: CGFloat) {
+        containerBottomConstraint?.update(offset: -keyboardHeight)
+        UIView.animate(withDuration: 0.3) {
+            self.view.layoutIfNeeded()
+            self.walktalkChatView.scrollToBottom()
+        }
+    }
+
+    func keyboardWillHide() {
+        containerBottomConstraint?.update(offset: -38)
+        UIView.animate(withDuration: 0.3) {
+            self.view.layoutIfNeeded()
+        }
     }
 }

--- a/walkmong/walkmong/Presentation/Walktalk/Chat/Views/WalktalkChatMessageReceivedCollectionViewCell.swift
+++ b/walkmong/walkmong/Presentation/Walktalk/Chat/Views/WalktalkChatMessageReceivedCollectionViewCell.swift
@@ -89,24 +89,17 @@ class WalktalkChatMessageReceivedCollectionViewCell: UICollectionViewCell {
     }
     
     override func preferredLayoutAttributesFitting(_ layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
-        // 레이아웃 속성 복사
         let attributes = super.preferredLayoutAttributesFitting(layoutAttributes)
 
-        // 가로 너비를 고정
         let fixedWidth = layoutAttributes.frame.width
         let targetSize = CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude)
 
-        // Auto Layout 기반 높이 계산
         let calculatedSize = contentView.systemLayoutSizeFitting(
             targetSize,
             withHorizontalFittingPriority: .required,
             verticalFittingPriority: .fittingSizeLevel
         )
 
-        // 디버깅: 계산된 크기 확인
-        print("IndexPath: \(layoutAttributes.indexPath), Calculated Size: \(calculatedSize)")
-
-        // 고정된 너비와 계산된 높이 설정
         attributes.frame.size = CGSize(width: fixedWidth, height: calculatedSize.height)
         return attributes
     }

--- a/walkmong/walkmong/Presentation/Walktalk/Chat/Views/WalktalkChatMessageSentCollectionViewCell.swift
+++ b/walkmong/walkmong/Presentation/Walktalk/Chat/Views/WalktalkChatMessageSentCollectionViewCell.swift
@@ -73,24 +73,17 @@ class WalktalkChatMessageSentCollectionViewCell: UICollectionViewCell {
     }
     
     override func preferredLayoutAttributesFitting(_ layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
-        // 레이아웃 속성 복사
         let attributes = super.preferredLayoutAttributesFitting(layoutAttributes)
 
-        // 가로 너비를 고정
         let fixedWidth = layoutAttributes.frame.width
         let targetSize = CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude)
 
-        // Auto Layout 기반 높이 계산
         let calculatedSize = contentView.systemLayoutSizeFitting(
             targetSize,
             withHorizontalFittingPriority: .required,
             verticalFittingPriority: .fittingSizeLevel
         )
 
-        // 디버깅: 계산된 크기 확인
-        print("IndexPath: \(layoutAttributes.indexPath), Calculated Size: \(calculatedSize)")
-
-        // 고정된 너비와 계산된 높이 설정
         attributes.frame.size = CGSize(width: fixedWidth, height: calculatedSize.height)
         return attributes
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!--ex) #이슈번호, #이슈번호-->
#123 

### #️⃣ 이슈 닫기
<!--'close #이슈번호' 입력하면 됩니다!-->
close #123 

## 📝 작업 내용
<!--이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)-->

```swift
protocol KeyboardObserverDelegate: AnyObject {
    func keyboardWillShow(keyboardHeight: CGFloat)
    func keyboardWillHide()
}
```
많은 고민을 해보았으나 뷰 레이아웃이 제각각이어서 
(`bottom.equalToSuperview()`로 제약조건을 해놓은 경우, `frame`의 좌표를 옮겨도 무의미)
델리게이트 패턴으로 뷰 구조에 따라 델리게이트 메소드 내에서 커스텀할 수 있도록 구현하였습니다 (최선이었습니다..) .. 하지만 복잡합니다

### 📋 KeyboardEventManager 사용 방법

**1. VC내에서 KeyboardEventManager 인스턴스 생성하고 VC에 델리게이트 위임하기**
```swift
private var keyboardEventManager: KeyboardEventManager?

...

override func viewDidLoad() {

    ...

    keyboardEventManager = KeyboardEventManager(delegate: self)
}
```

**2. 해당하는 View의 Constraint 변수 생성하고 적용하기**

```swift
import SnapKit

final class {해당하는 VC}: UIViewController {

...

private var {해당하는 View의 Constraint 변수}: Constraint?

...

{해당하는 View}.snp.makeConstraints { make in
    ...
    containerBottomConstraint = make.bottom.equalToSuperview().offset(-38).constraint // 예시
}
```

**3. 델리게이트 메소드 구현하기**

```swift
extension {해당하는 VC}: KeyboardObserverDelegate {
    func keyboardWillShow(keyboardHeight: CGFloat) {
        {해당하는 View의 Constraint 변수}?.update(offset: -keyboardHeight)
        UIView.animate(withDuration: 0.3) {
            self.view.layoutIfNeeded()
        }
    }

    func keyboardWillHide() {
        {해당하는 View의 Constraint 변수}?.update(offset: 0)
        UIView.animate(withDuration: 0.3) {
            self.view.layoutIfNeeded()
        }
    }
}
```

### 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
<!--작업 중 궁금한 내용이나 논의할 사항을 적어주세요!-->

