### PR TITLE
[Design] 산책 정보 페이지 맵뷰 추가

### DIFF
--- a/walkmong/walkmong/Presentation/MatchingStatus/WalkInfoForOwner/Views/MatchingStatusWalkInfoForOwnerView.swift
+++ b/walkmong/walkmong/Presentation/MatchingStatus/WalkInfoForOwner/Views/MatchingStatusWalkInfoForOwnerView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import SnapKit
+import NMapsMap
 
 final class MatchingStatusWalkInfoForOwnerView: UIView {
     
@@ -41,7 +42,22 @@ final class MatchingStatusWalkInfoForOwnerView: UIView {
         label.textColor = UIColor(hexCode: "#444444")
         return label
     }()
-    private let mapView = UIView.createRoundedView(backgroundColor: .red, cornerRadius: 15)
+    private let mapView: NMFNaverMapView = {
+        let mapView = NMFNaverMapView()
+        return mapView
+    }()
+    private let mapBlockerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .clear
+        return view
+    }()
+    
+    private let centerMarker: CustomMarker = {
+        let marker = CustomMarker()
+        marker.height = 60
+        marker.width = 47
+        return marker
+    }()
     private let walkItemTitle = SmallTitleLabel(text: "산책 준비물")
     private let walkItemleadLineButton = UIButton.createStyledButton(type: .largeSelectionCheck, style: .light, title: "리드줄(목줄)")
     private let walkItemleadPoopBagButton = UIButton.createStyledButton(type: .largeSelectionCheck, style: .light, title: "배변봉투")
@@ -149,7 +165,7 @@ final class MatchingStatusWalkInfoForOwnerView: UIView {
             make.leading.trailing.equalToSuperview().inset(20)
         }
         
-        meetingPlaceView.addSubviews(locationIcon, locationLabel, locationDescriptionLabel, mapView)
+        meetingPlaceView.addSubviews(locationIcon, locationLabel, locationDescriptionLabel, mapView, mapBlockerView)
         locationIcon.snp.makeConstraints { make in
             make.centerY.equalTo(locationLabel)
             make.leading.equalToSuperview().offset(12)
@@ -166,6 +182,13 @@ final class MatchingStatusWalkInfoForOwnerView: UIView {
         }
         
         mapView.snp.makeConstraints { make in
+            make.top.equalTo(locationDescriptionLabel.snp.bottom).offset(10)
+            make.leading.trailing.equalToSuperview().inset(12)
+            make.height.equalTo(mapView.snp.width)
+            make.bottom.equalToSuperview().inset(12)
+        }
+        
+        mapBlockerView.snp.makeConstraints { make in
             make.top.equalTo(locationDescriptionLabel.snp.bottom).offset(10)
             make.leading.trailing.equalToSuperview().inset(12)
             make.height.equalTo(mapView.snp.width)
@@ -283,5 +306,15 @@ final class MatchingStatusWalkInfoForOwnerView: UIView {
     private func setupInitialButtonStyle(_ button: UIButton) {
         button.backgroundColor = .white
         button.setTitleColor(.gray500, for: .normal)
+    }
+    
+    func setupMap(initialPosition: NMGLatLng) {
+        let cameraUpdate = NMFCameraUpdate(scrollTo: initialPosition, zoomTo: 15)
+        mapView.mapView.moveCamera(cameraUpdate)
+        mapView.showScaleBar = false
+        mapView.showZoomControls = false
+        mapView.isUserInteractionEnabled = false
+        centerMarker.position = initialPosition
+        centerMarker.mapView = mapView.mapView
     }
 }

--- a/walkmong/walkmong/Presentation/MatchingStatus/WalkInfoForWalker/Views/MatchingStatusWalkInfoForWalkerView.swift
+++ b/walkmong/walkmong/Presentation/MatchingStatus/WalkInfoForWalker/Views/MatchingStatusWalkInfoForWalkerView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import SnapKit
+import NMapsMap
 
 final class MatchingStatusWalkInfoForWalkerView: UIView {
     
@@ -40,7 +41,22 @@ final class MatchingStatusWalkInfoForWalkerView: UIView {
         label.textColor = UIColor(hexCode: "#444444")
         return label
     }()
-    private let mapView = UIView.createRoundedView(backgroundColor: .red, cornerRadius: 15)
+    private let mapView: NMFNaverMapView = {
+        let mapView = NMFNaverMapView()
+        return mapView
+    }()
+    private let mapBlockerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .clear
+        return view
+    }()
+    
+    private let centerMarker: CustomMarker = {
+        let marker = CustomMarker()
+        marker.height = 60
+        marker.width = 47
+        return marker
+    }()
 
     private let buttonFrame = UIView()
     private let walkTalkButton = CustomButtonView(
@@ -168,7 +184,7 @@ final class MatchingStatusWalkInfoForWalkerView: UIView {
             make.bottom.equalToSuperview().inset(43)
         }
         
-        meetingPlaceView.addSubviews(locationIcon, locationLabel, locationDescriptionLabel, mapView)
+        meetingPlaceView.addSubviews(locationIcon, locationLabel, locationDescriptionLabel, mapView, mapBlockerView)
         locationIcon.snp.makeConstraints { make in
             make.centerY.equalTo(locationLabel)
             make.leading.equalToSuperview().offset(12)
@@ -185,6 +201,11 @@ final class MatchingStatusWalkInfoForWalkerView: UIView {
         }
         
         mapView.snp.makeConstraints { make in
+            make.top.equalTo(locationDescriptionLabel.snp.bottom).offset(10)
+            make.leading.trailing.bottom.equalToSuperview().inset(12)
+            make.height.equalTo(mapView.snp.width)
+        }
+        mapBlockerView.snp.makeConstraints { make in
             make.top.equalTo(locationDescriptionLabel.snp.bottom).offset(10)
             make.leading.trailing.bottom.equalToSuperview().inset(12)
             make.height.equalTo(mapView.snp.width)
@@ -208,4 +229,15 @@ final class MatchingStatusWalkInfoForWalkerView: UIView {
             make.leading.trailing.equalToSuperview().inset(12)
         }
     }
+    
+    func setupMap(initialPosition: NMGLatLng) {
+        let cameraUpdate = NMFCameraUpdate(scrollTo: initialPosition, zoomTo: 15)
+        mapView.mapView.moveCamera(cameraUpdate)
+        mapView.showScaleBar = false
+        mapView.showZoomControls = false
+        mapView.isUserInteractionEnabled = false
+        centerMarker.position = initialPosition
+        centerMarker.mapView = mapView.mapView
+    }
+
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!--ex) #이슈번호, #이슈번호-->
#155 

### #️⃣ 이슈 닫기
<!--'close #이슈번호' 입력하면 됩니다!-->
close #155 

## 📝 작업 내용
<!--이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)-->
- 맵뷰를 추가했습니다
- `setupMap(initialPosition: NMGLatLng)`을 통해 위도,경도로 뷰컨트롤러에서 맵뷰에 접근하면 됩니다
- `mapBlockerView`로 맵뷰와 사용자 인터렉션을 막도록 하였습니다.
- 중앙에 `centerMarker`를 띄우도록 하였습니다.

### 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
<!--작업 중 궁금한 내용이나 논의할 사항을 적어주세요!-->

