### PR TITLE
[Fix] 산책 지원 로직 API / UI 및 회원가입 로직 API 디버깅

### DIFF
--- a/walkmong/walkmong/Application/SceneDelegate.swift
+++ b/walkmong/walkmong/Application/SceneDelegate.swift
@@ -67,6 +67,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 return
             }
         }
+        UserDefaults.standard.set(false, forKey: "KEEP_LOGIN")
         if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
             let loginViewController = LoginViewController()
             sceneDelegate.changeRootViewController(loginViewController, animated: true)

--- a/walkmong/walkmong/Global/Extension/UIView+.swift
+++ b/walkmong/walkmong/Global/Extension/UIView+.swift
@@ -70,4 +70,19 @@ extension UIView {
         view.layer.masksToBounds = true
         return view
     }
+    
+    func formatDate(from input: String) -> String? {
+        let inputFormatter = DateFormatter()
+        inputFormatter.dateFormat = "yyyy-MM-dd"
+        inputFormatter.locale = Locale(identifier: "ko_KR") // 한국어 요일 표현을 위해 설정
+        
+        let outputFormatter = DateFormatter()
+        outputFormatter.dateFormat = "yyyy.MM.dd (E) " // 원하는 형식
+        outputFormatter.locale = Locale(identifier: "ko_KR")
+        
+        guard let date = inputFormatter.date(from: input) else {
+            return nil // 입력 문자열이 날짜 형식에 맞지 않는 경우
+        }
+        return outputFormatter.string(from: date)
+    }
 }

--- a/walkmong/walkmong/Network/Manager/AuthManager.swift
+++ b/walkmong/walkmong/Network/Manager/AuthManager.swift
@@ -46,6 +46,6 @@ class AuthManager {
     }
     
     func isLoggedIn() -> Bool {
-        return accessToken != nil
+        return accessToken != nil && UserDefaults.standard.bool(forKey: "KEEP_LOGIN")
     }
 }

--- a/walkmong/walkmong/Network/Response/APIResponse.swift
+++ b/walkmong/walkmong/Network/Response/APIResponse.swift
@@ -14,12 +14,29 @@ struct APIResponse<DTO: Decodable>: Decodable {
 }
 
 enum NetworkError: Error {
-    case clientError(message: String)
+    case errorWithMessage(message: String)
     case serverError
     case unauthorized
     case tokenRefreshFailed
     case forbidden
     case unknown
+    
+    var message: String {
+        switch self {
+        case .unauthorized:
+            return "Unauthorized access. Please log in again."
+        case .forbidden:
+            return "You do not have permission to perform this action."
+        case .errorWithMessage(let message):
+            return (message)
+        case .serverError:
+            return "Server error. Please try again later."
+        case .tokenRefreshFailed:
+            return "Failed to refresh the token. Please log in again."
+        case .unknown:
+            return "An unknown error occurred."
+        }
+    }
 }
 
 struct EmptyDTO: Decodable {}

--- a/walkmong/walkmong/Network/Service/ApplyService.swift
+++ b/walkmong/walkmong/Network/Service/ApplyService.swift
@@ -10,11 +10,11 @@ import Foundation
 struct ApplyService {
     private let provider = NetworkProvider<ApplyAPI>()
     
-    func applyWalk(boardId: Int, request: WalkRequestData) async throws -> APIResponse<String> {
+    func applyWalk(boardId: Int, request: WalkRequestData) async throws -> APIResponse<Int> {
         let request = ["dongAddress":request.dongAddress, "roadAddress": request.roadAddress, "latitude": request.latitude, "longitude": request.longitude, "addressDetail": request.addressDetail, "addressMemo": request.addressMemo, "poopBagYn": request.poopBagYn, "muzzleYn": request.muzzleYn, "dogCollarYn": request.dogCollarYn, "preMeetingYn": request.preMeetingYn, "memoToOwner": request.memoToOwner]
         return try await provider.request(
             target: .applyWalk(boardId: boardId, request: request),
-            responseType: APIResponse<String>.self
+            responseType: APIResponse<Int>.self
         )
     }
     

--- a/walkmong/walkmong/Network/Service/AuthService.swift
+++ b/walkmong/walkmong/Network/Service/AuthService.swift
@@ -11,10 +11,10 @@ import Moya
 struct AuthService {
     private let provider = NetworkProvider<AuthAPI>()
     
-    func signup(request: SignupRequest) async throws -> APIResponse<String> {
+    func signup(request: SignupRequest) async throws -> APIResponse<Int> {
         return try await provider.request(
             target: .signup(request: request),
-            responseType: APIResponse<String>.self
+            responseType: APIResponse<Int>.self
         )
     }
 

--- a/walkmong/walkmong/Network/Service/AuthService.swift
+++ b/walkmong/walkmong/Network/Service/AuthService.swift
@@ -27,7 +27,7 @@ struct AuthService {
             )
         } catch let error as MoyaError {
             if case .statusCode(let response) = error, (400...499).contains(response.statusCode) {
-                throw NetworkError.clientError(message: error.localizedDescription)
+                throw NetworkError.errorWithMessage(message: error.localizedDescription)
             }
             throw error
         }

--- a/walkmong/walkmong/Network/Service/MemberService.swift
+++ b/walkmong/walkmong/Network/Service/MemberService.swift
@@ -11,10 +11,10 @@ import Moya
 struct MemberService {
     private let provider = NetworkProvider<MemberAPI>()
     
-    func postAddress(request: PostAddressRequest) async throws -> APIResponse<String> {
+    func postAddress(request: PostAddressRequest) async throws -> APIResponse<Int> {
         return try await provider.request(
             target: .postAddress(request: request),
-            responseType: APIResponse<String>.self
+            responseType: APIResponse<Int>.self
         )
     }
     

--- a/walkmong/walkmong/Presentation/Login/ViewController/LoginViewController.swift
+++ b/walkmong/walkmong/Presentation/Login/ViewController/LoginViewController.swift
@@ -71,12 +71,13 @@ extension LoginViewController: LoginViewDelegate {
     }
     
     private func handleLoginSuccess(response: RefreshAccessTokenResponse, keepLogin: Bool, keepEmail: String? = nil) {
+        AuthManager.shared.accessToken = response.data.accessToken
+        AuthManager.shared.refreshToken = response.data.refreshToken
         if keepLogin {
-            AuthManager.shared.accessToken = response.data.accessToken
-            AuthManager.shared.refreshToken = response.data.refreshToken
+            UserDefaults.standard.setValue(keepLogin, forKey: "KEEP_LOGIN")
         }
         if let keepEmail = keepEmail {
-            UserDefaults.setValue(keepEmail, forKey: "USER_EMAIL")
+            UserDefaults.standard.setValue(keepEmail, forKey: "USER_EMAIL")
         }
         let mainTabBarController = MainTabBarController()
         let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate

--- a/walkmong/walkmong/Presentation/MatchingApply/DetailSelect/ViewController/MatchingApplyDetailSelectViewController.swift
+++ b/walkmong/walkmong/Presentation/MatchingApply/DetailSelect/ViewController/MatchingApplyDetailSelectViewController.swift
@@ -64,8 +64,8 @@ extension MatchingApplyDetailSelectViewController: MatchingApplyDetailSelectView
         self.matchingApplyRequest.addressMemo = model.memo ?? ""
         self.matchingApplyRequest.roadAddress = model.roadAddress ?? ""
         self.matchingApplyRequest.dongAddress = model.dongAddress ?? ""
-        self.matchingApplyRequest.latitude = String(describing: model.latitude)
-        self.matchingApplyRequest.longitude = String(describing: model.longitude)
+        self.matchingApplyRequest.latitude = String(model.latitude)
+        self.matchingApplyRequest.longitude = String(model.longitude)
         updateNextButtonState()
     }
     

--- a/walkmong/walkmong/Presentation/MatchingApply/DetailSelect/ViewController/MatchingApplyDetailSelectViewController.swift
+++ b/walkmong/walkmong/Presentation/MatchingApply/DetailSelect/ViewController/MatchingApplyDetailSelectViewController.swift
@@ -17,6 +17,7 @@ final class MatchingApplyDetailSelectViewController: UIViewController {
     
     func configure(with boardDetail: BoardDetail) {
         self.boardDetail = boardDetail
+        detailSelectView.setContent(boardDetail: boardDetail)
     }
       
     init(boardDetail: BoardDetail, boardId: Int){

--- a/walkmong/walkmong/Presentation/MatchingApply/DetailSelect/Views/MatchingApplyDetailSelectView.swift
+++ b/walkmong/walkmong/Presentation/MatchingApply/DetailSelect/Views/MatchingApplyDetailSelectView.swift
@@ -121,7 +121,7 @@ class MatchingApplyDetailSelectView: UIView {
         return imageView
     }()
     
-    private let selectPlaceWarningMessageLabel = SmallMainHighlightParagraphLabel(text: "장소 선택 후 반려인과 상의하여 장소를 변경해도 괜찮아요!", textColor: .gray600)
+    private let selectPlaceWarningMessageLabel = SmallMainHighlightParagraphLabel(text: "장소 선택 후 반려인과 상의하여 장소를 변경해도 괜찮아요!", textColor: .mainBlue)
     
     //TODO: 선택한 장소에 따라 UI 업데이트
     private let selectedPlaceLabel = SmallTitleLabel(text: "강남구 학동로 508", textColor: .gray600)
@@ -711,4 +711,12 @@ class MatchingApplyDetailSelectView: UIView {
         placeSelectButtonLabel.removeFromSuperview()
         placeSelectButtonArrowIcon.removeFromSuperview()
     }
+    
+    func setContent(boardDetail: BoardDetail) {
+        if let startDate = formatDate(from: boardDetail.date!), let endDate = formatDate(from: boardDetail.date!){
+            calendarStartDateLabel.text = startDate + boardDetail.startTime
+            calendarEndDateLabel.text = endDate + boardDetail.endTime
+        }
+    }
+    
 }

--- a/walkmong/walkmong/Presentation/MatchingApply/Final/ViewController/MatchingApplyFinalViewController.swift
+++ b/walkmong/walkmong/Presentation/MatchingApply/Final/ViewController/MatchingApplyFinalViewController.swift
@@ -14,6 +14,7 @@ class MatchingApplyFinalViewController: UIViewController {
     private var boardDetailData: BoardDetail!
     private var boardId: Int!
     private var checked: Bool = false
+    private let service = ApplyService()
     
     init(matchingApplyRequest: WalkRequestData, boardDetailData: BoardDetail, boardId: Int){
         self.boardDetailData = boardDetailData
@@ -62,9 +63,9 @@ extension MatchingApplyFinalViewController: MatchingApplyFinalViewDelegate {
     func didTapApplyButton() {
         if checked {
             Task {
-                let service = ApplyService()
                 do {
-                    _ = try await service.applyWalk(boardId: boardId, request: matchingApplyRequest)
+                    let response = try await service.applyWalk(boardId: boardId, request: matchingApplyRequest)
+                    print("지원 성공: \(response)")
                     CustomAlertViewController
                         .CustomAlertBuilder(viewController: self)
                         .setTitleState(.useTitleOnly)
@@ -73,12 +74,12 @@ extension MatchingApplyFinalViewController: MatchingApplyFinalViewDelegate {
                         .setSingleButtonTitle("확인")
                         .showAlertView()
                     self.navigationController?.popToRootViewController(animated: true)
-                }catch {
+                }catch let error as NetworkError {
                     CustomAlertViewController
                         .CustomAlertBuilder(viewController: self)
                         .setTitleState(.useTitleAndSubTitle)
                         .setTitleText("산책 지원 실패")
-                        .setSubTitleText("네트워크 상태를 확인해주세요.")
+                        .setSubTitleText(error.message)
                         .setButtonState(.singleButton)
                         .setSingleButtonTitle("돌아가기")
                         .showAlertView()

--- a/walkmong/walkmong/Presentation/MatchingApply/Final/Views/MatchingApplyFinalView.swift
+++ b/walkmong/walkmong/Presentation/MatchingApply/Final/Views/MatchingApplyFinalView.swift
@@ -209,7 +209,7 @@ class MatchingApplyFinalView: UIView {
         planStartInformationView.snp.makeConstraints { make in
             make.top.equalTo(planTitleLabel.snp.bottom).offset(16)
             make.leading.equalToSuperview().offset(20)
-            make.height.equalTo(67)
+            make.height.equalTo(89)
             make.width.equalTo(scrollContentView.snp.width).multipliedBy(0.5).offset(-24)
         }
         planStartLabel.snp.makeConstraints { make in
@@ -222,7 +222,7 @@ class MatchingApplyFinalView: UIView {
         }
         planEndInformationView.snp.makeConstraints { make in            make.top.equalTo(planTitleLabel.snp.bottom).offset(16)
             make.trailing.equalToSuperview().inset(20)
-            make.height.equalTo(67)
+            make.height.equalTo(89)
             make.width.equalTo(scrollContentView.snp.width).multipliedBy(0.5).offset(-24)
         }
         planEndLabel.snp.makeConstraints { make in
@@ -334,8 +334,11 @@ class MatchingApplyFinalView: UIView {
         }
         dogInformationView.configure(isFemale: boardDetail.dogGender == "MALE" ? false : true, name: boardDetail.dogName, informationText: "\(dogSize) · \(boardDetail.breed) · \(boardDetail.weight)kg", location: "\(boardDetail.dongAddress) \(String(format: "%.2f", (boardDetail.distance)))km", profileImage: boardDetail.dogProfile ?? "프로필 이미지 오류")
         walkerInformationView.configure(name: boardDetail.ownerName, informationText: "\(boardDetail.ownerAge/10)0대 · 남성", location: requestData.dongAddress, profileImage: boardDetail.ownerProfile ?? "프로필 이미지 오류")
-        planStartDateLabel.text = boardDetail.startTime
-        planEndDateLabel.text = boardDetail.endTime
+        if let startDate = formatDate(from: boardDetail.date!),
+           let endDate = formatDate(from: boardDetail.date!) {
+            planStartDateLabel.text = startDate + "\n" + boardDetail.startTime
+            planEndDateLabel.text = endDate + "\n" + boardDetail.endTime
+        }
         placeAddressLabel.text = requestData.dongAddress + requestData.addressDetail
         placeMemoLabel.text = requestData.addressMemo
         messageLabel.text = requestData.memoToOwner

--- a/walkmong/walkmong/Presentation/MatchingApply/Final/Views/MatchingApplyFinalView.swift
+++ b/walkmong/walkmong/Presentation/MatchingApply/Final/Views/MatchingApplyFinalView.swift
@@ -344,6 +344,7 @@ class MatchingApplyFinalView: UIView {
     @objc private func checkBoxButtonTapped() {
         checkBoxButton.isSelected.toggle()
         nextButton.backgroundColor = checkBoxButton.isSelected ? .gray600 : .gray300
+        nextButton.setButtonState(isEnabled: checkBoxButton.isSelected)
         delegate?.didCheckedInformation(button: checkBoxButton)
     }
     

--- a/walkmong/walkmong/Presentation/MatchingApply/Map/Models/MatchingApplyMapModel.swift
+++ b/walkmong/walkmong/Presentation/MatchingApply/Map/Models/MatchingApplyMapModel.swift
@@ -11,8 +11,8 @@ struct MatchingApplyMapModel: Codable{
     var dongAddress: String?
     var roadAddress: String?
     var buildingName: String?
-    var latitude: Double?
-    var longitude: Double?
+    var latitude: Double = 0.0
+    var longitude: Double = 0.0
     var didSelectLocation: Bool
     var memo: String?
 }

--- a/walkmong/walkmong/Presentation/Signup/ProfileImage/ViewController/SignupProfileImageViewController.swift
+++ b/walkmong/walkmong/Presentation/Signup/ProfileImage/ViewController/SignupProfileImageViewController.swift
@@ -18,6 +18,7 @@ final class SignupProfileImageViewController: UIViewController {
     init(signupData: SignupRequest, addressData: PostAddressRequest) {
         super.init(nibName: nil, bundle: nil)
         self.signupData = signupData
+        self.addressData = addressData
     }
     
     required init?(coder: NSCoder) {
@@ -92,8 +93,9 @@ extension SignupProfileImageViewController: SignupProfileImageViewDelegate {
                     .setTitleState(.useTitleAndSubTitle)
                     .setSingleButtonTitle("돌아가기")
                     .setTitleText("회원가입 실패")
-                    .setSubTitleText("다시 시도해주세요.")
+                    .setSubTitleText(error.message)
                     .showAlertView()
+                print("알 수 없는 에러 발생: \(error.message)")
             } catch {
                 print("알 수 없는 에러 발생: \(error.localizedDescription)")
                 CustomAlertViewController.CustomAlertBuilder(viewController: self)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!--ex) #이슈번호, #이슈번호-->
#171 

### #️⃣ 이슈 닫기
<!--'close #이슈번호' 입력하면 됩니다!-->
#171 

## 📝 작업 내용
<!--이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)-->
- 회원가입에서 발생하던 주소 정보 저장 문제를 수정하였습니다
- 회원가입 프로필 사진 용량 제한 문제를 해결했습니다(백엔드)
- "로그인 유지"체크 하지 않을 시 액세스 토큰도 저장되지 않아 아무것도 안되는 문제(전 바보입니다)
  - "로그인 유지" 여부를 저장하는 `Bool` 데이터를 `UserDefaults`에 넣어놓고 `AuthManager`의 `isLoggedIn`에서 검사하도록 수정
- 산책 지원 과정에서 날짜 데이터를 전달하여 UI에 정상적으로 반영되도록 수정하였습니다
- 산책 지원 버튼의 enable 상태를 true로 해놓지 않아 버튼이 눌리지 않던 문제를 수정하였습니다

### 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
<!--작업 중 궁금한 내용이나 논의할 사항을 적어주세요!-->

